### PR TITLE
tblocker service name and path, adguard data_output fix

### DIFF
--- a/reverse_proxy_server.sh
+++ b/reverse_proxy_server.sh
@@ -966,7 +966,7 @@ marz_bot_install() {
         -e "s|^#\?\s*AdminBotToken:.*$|AdminBotToken: \"${BOT_TOKEN_BAN_LIMIT_OR_TORRENT}\"|" \
         -e "s|^#\?\s*LogFile:.*$|LogFile: \"/var/lib/marzban/log/access.log\"|" \
         -e "s|^#\?\s*BlockDuration:.*$|BlockDuration: 1|" \
-        /opt/torrent-blocker/config.yaml
+        /opt/tblocker/config.yaml
 
     if [[ "$BOT_CHOISE" == "2" ]]; then
         jq '(.log) = {
@@ -1050,8 +1050,8 @@ EOF
 
     # Настройка дизайна подписки
     sudo wget -N -P /var/lib/marzban/templates/subscription/ https://raw.githubusercontent.com/cortez24rus/marz-sub/refs/heads/main/index.html
-    systemctl stop torrent-blocker
-    systemctl start torrent-blocker
+    systemctl stop tblocker
+    systemctl start tblocker
     timeout 7 marzban up
 
     tilda "$(text 10)"
@@ -1161,7 +1161,7 @@ data_output() {
     printf '0\n' | marzban status | grep --color=never -i ':'
     echo
     out_data " $(text 59) " "https://${DOMAIN}/${WEBBASEPATH}/"
-    if [[ $choise = "1" ]]; then
+    if [[ $choise == "2" ]]; then
         out_data " $(text 61) " "https://${DOMAIN}/${ADGUARDPATH}/login.html"
     fi
     echo

--- a/reverse_proxy_server.sh
+++ b/reverse_proxy_server.sh
@@ -1161,7 +1161,7 @@ data_output() {
     printf '0\n' | marzban status | grep --color=never -i ':'
     echo
     out_data " $(text 59) " "https://${DOMAIN}/${WEBBASEPATH}/"
-    if [[ $choise == "2" ]]; then
+    if [[ $CHOISE == "2" ]]; then
         out_data " $(text 61) " "https://${DOMAIN}/${ADGUARDPATH}/login.html"
     fi
     echo


### PR DESCRIPTION
Во время установки по скрипту (dev и main branch) возникли проблемы:
- если выбирать adguard, то в data_output не выводилась информация о нем ✅  
- torrent-blocker также выдает ошибки во время установки, по путям же лежит не torrent-blocker, а tblocker, служба соот-но тоже `tblocker.service` ✅ 

Дальше уже стоило бы расписать в Issues, но пользуясь моментом напишу
Ubuntu 22.04.05, после установки ОС было выполнено: 
- `unminimize && apt-get update && apt-get full-upgrade -y && apt autoclean -y && apt clean -y && apt autoremove -y && reboot`
- установлен xanmod

nginx не установился, т.к. по завершении не было доступа к панели и во время установки были соответстующие ошибки связанные с nginx (ниже). на двух машинах установка не успешна, если ставлю руками через `apt install nginx`, то спрашивает что делать с уже существующим `nginx.conf`, после ставится и всё работает.

```
Can't open "/etc/nginx/dhparam.pem" for writing, No such file or directory
405784FC3B7F0000:error:80000002:system library:BIO_new_file:No such file or directory:../crypto/bio/bss_file.c:67:calling fopen(/etc/nginx/dhparam.pem, w)
405784FC3B7F0000:error:10000080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:75:

|-----------------------------------------------------------------------------|

 Настройка NGINX. 
/dev/fd/63: line 772: /etc/nginx/conf.d/local.conf: No such file or directory
 Обновляем пакеты и устанавливаем zip... 
Hit:1 http://nginx.org/packages/ubuntu jammy InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Hit:5 http://security.ubuntu.com/ubuntu jammy-security InRelease
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
zip is already the newest version (3.0-12build2).
unzip is already the newest version (6.0-26ubuntu3.2).
unzip set to manually installed.
wget is already the newest version (1.21.2-2ubuntu1.1).
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
 Создаем необходимые папки... 
[?]  Скачиваем шаблоны... 
[?]  Удаляем ненужные файлы... 
[?]  Random template name: aroma-beauty-and-spa-responsive-bootstrap-template/ 
[?]  Копируем шаблон в /var/www/html/... 
[OK]  Шаблон успешно извлечен и установлен! 
Failed to restart nginx.service: Unit nginx.service not found.
/dev/fd/63: line 689: nginx: command not found
```

других логов что-то я не усмотрел

- при попытке зайти в панельку adguard выдает `Error: control/login | [object Object] | 404...`
![image](https://github.com/user-attachments/assets/81fa231f-2648-40d5-a8df-724ed6958252)
![image2](https://github.com/user-attachments/assets/e809233c-35b7-49a2-ba7d-d8de5f051aee)